### PR TITLE
Add button positions and sizes

### DIFF
--- a/examples/button.rb
+++ b/examples/button.rb
@@ -1,7 +1,7 @@
 require "scarpe"
 
 Scarpe.app do
-  @push = button "Push me"
+  @push = button "Push me", width: 200, height: 50
   @note = para "Nothing pushed so far"
   @push.click {
     @note.replace "Aha! Click!"

--- a/examples/button.rb
+++ b/examples/button.rb
@@ -1,7 +1,7 @@
 require "scarpe"
 
 Scarpe.app do
-  @push = button "Push me", width: 200, height: 50
+  @push = button "Push me", width: 200, height: 50, top: 109, left: 132
   @note = para "Nothing pushed so far"
   @push.click {
     @note.replace "Aha! Click!"

--- a/examples/button_with_position_and_size.rb
+++ b/examples/button_with_position_and_size.rb
@@ -1,7 +1,7 @@
 require "scarpe"
 
 Scarpe.app do
-  @push = button "Push me"
+  @push = button "Push me", width: 200, height: 50, top: 109, left: 132
   @note = para "Nothing pushed so far"
   @push.click {
     @note.replace "Aha! Click!"

--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -1,10 +1,12 @@
 module Scarpe
   class Button
-    def initialize(app, text, width:, height:, &block)
+    def initialize(app, text, width:, height:, top:, left: , &block)
       @app = app
       @text = text
       @width = width
       @height = height
+      @top = top
+      @left = left
       @block = block
       @app.append(render)
     end
@@ -28,8 +30,13 @@ module Scarpe
 
     def style
       styles = {}
+      
       styles[:width] = "#{@width}px" if @width
       styles[:height] = "#{@height}px" if @height
+
+      styles[:top] = "#{@top}px" if @top
+      styles[:left] = "#{@left}px" if @left
+      styles[:position] = "absolute" if @top || @left
 
       styles.map { |k, v| "#{k}:#{v}" }.join(";")
     end

--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -1,8 +1,10 @@
 module Scarpe
   class Button
-    def initialize(app, text, &block)
+    def initialize(app, text, width:, height:, &block)
       @app = app
       @text = text
+      @width = width
+      @height = height
       @block = block
       @app.append(render)
     end
@@ -17,11 +19,19 @@ module Scarpe
 
     def render
       @app.bind(function_name) do
-        if @block
-          @block.call
-        end
+        @block.call if @block
       end
-      "<button id=#{object_id} onclick='scarpeHandler(#{function_name})'>#{@text}</button>"
+      "<button id=#{object_id} onclick='scarpeHandler(#{function_name})' style='#{style}'>#{@text}</button>"
+    end
+
+    private
+
+    def style
+      styles = {}
+      styles[:width] = "#{@width}px" if @width
+      styles[:height] = "#{@height}px" if @height
+
+      styles.map { |k, v| "#{k}:#{v}" }.join(";")
     end
   end
 end

--- a/lib/scarpe/internal_app.rb
+++ b/lib/scarpe/internal_app.rb
@@ -33,8 +33,8 @@ module Scarpe
     def flow(&block)
       Scarpe::Flow.new(self, &block)
     end
-    def button(text, width: nil, height: nil, &block)
-      Scarpe::Button.new(self, text, width:, height:, &block)
+    def button(text, width: nil, height: nil, top: nil, left: nil, &block)
+      Scarpe::Button.new(self, text, width:, height:, top:, left:, &block)
     end
     def image(url)
       Scarpe::Image.new(self, url)

--- a/lib/scarpe/internal_app.rb
+++ b/lib/scarpe/internal_app.rb
@@ -33,8 +33,8 @@ module Scarpe
     def flow(&block)
       Scarpe::Flow.new(self, &block)
     end
-    def button(text, &block)
-      Scarpe::Button.new(self, text, &block)
+    def button(text, width: nil, height: nil, &block)
+      Scarpe::Button.new(self, text, width:, height:, &block)
     end
     def image(url)
       Scarpe::Image.new(self, url)


### PR DESCRIPTION
This allows setting `width:`, `height:`, `top:`, and `left:` for buttons.

This should address the coordinate and size points of #4

The properties also all work independently, so you can set only width and top for example.

<img width="479" alt="Screenshot 2023-02-06 at 11 58 50" src="https://user-images.githubusercontent.com/207504/216954717-8bb31820-d3c9-4448-83b7-dca81c57353a.png">

Usage:
```ruby
@button = button "Push me", width: 200, height: 50, top: 109, left: 132
```

You can try it by running `bundle exec ruby examples/button_with_position_and_size.rb` from the repo