### PR TITLE
Add CLI scarpe app to run example files

### DIFF
--- a/exe/scarpe
+++ b/exe/scarpe
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+use_dev = ARGV.delete("--dev") ? true : false
+use_shoes = ARGV.delete("--no-shoes") ? false : true
+
+if ARGV.length != 1
+    puts <<USAGE
+Usage: scarpe [OPTIONS] <scarpe app file>
+  Options:
+      --dev                          Use development local scarpe, not an installed gem
+      --no-shoes                     Do not define a Shoes alias for Shoes compatibility
+USAGE
+    exit -1
+end
+
+if use_dev
+    dev_path = File.expand_path("../lib", __dir__)
+    $LOAD_PATH.prepend dev_path
+end
+
+require "scarpe"
+
+if use_shoes
+    Shoes = Scarpe
+end
+
+# Run the Scarpe app file
+load ARGV[0]


### PR DESCRIPTION
Without --no-shoes, it will add an alias for Scarpe called "Shoes" to run Shoes apps. It will auto-preload Scarpe. If run with --dev, it will use local-dev Scarpe in the same repo, not installed Scarpe.