### PR TITLE
Update HTML DSL to support multiple child elements

### DIFF
--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -8,7 +8,7 @@ module Scarpe
 
     def initialize(&block)
       @buffer = ""
-      @buffer += block.call(self)
+      block.call(self)
     end
 
     def value
@@ -26,16 +26,15 @@ module Scarpe
     def method_missing(name, *args, &block)
       raise NoMethodError, "no method #{name} for #{self.class.name}" unless TAGS.include?(name)
 
-      buffer = "<#{name} #{render_attributes(*args)}>"
-      buffer += if block_given?
-                  block.call(self)
-                else
-                  args.first
-                end
+      @buffer += "<#{name} #{render_attributes(*args)}>"
+      if block_given?
+        result = block.call(self)
+        @buffer += result if result.is_a?(String)
+      else
+        @buffer += args.first
+      end
 
-      buffer += "</#{name}>"
-
-      buffer
+      @buffer += "</#{name}>"
     end
 
     private


### PR DESCRIPTION
There was a bug that caused the HTML DSL to not support multiple child elements.

Example:
```
h.div do
  h.div { "1" }
  h.div { "2" }
end
```
only rendered "2" instead of "1 2".
By using a global buffer (again), we can simply append all elements to the string output.

@TobiasBales I've solved the issue of strings in blocks by checking if the result of a block call is a string and if so, appending it to the buffer. Works with both a string as the first argument and as the return value of a block. I think we should still write some simple tests for the DSL to prevent regressions or other unexpected bugs.