### PR TITLE
Make para accept multiple arguments

### DIFF
--- a/examples/para/collection_of_arguments.rb
+++ b/examples/para/collection_of_arguments.rb
@@ -1,0 +1,9 @@
+require "scarpe"
+
+Scarpe.app do
+  para "Testing test test. ",
+   "Breadsticks. ",
+   "Breadsticks. ",
+   "Breadsticks. ",
+   "Very good."
+end

--- a/examples/para/hello_world.rb
+++ b/examples/para/hello_world.rb
@@ -1,0 +1,5 @@
+require "scarpe"
+
+Scarpe.app do
+  para "Hello world"
+end

--- a/lib/scarpe/internal_app.rb
+++ b/lib/scarpe/internal_app.rb
@@ -24,9 +24,10 @@ module Scarpe
       @window.eval("document.getElementById(#{current_id}).insertAdjacentHTML('beforeend', \`#{el}\`)")
     end
 
-    def para(text)
+    def para(*text)
       Scarpe::Para.new(self, text)
     end
+
     def stack(&block)
       Scarpe::Stack.new(self, &block)
     end

--- a/lib/scarpe/para.rb
+++ b/lib/scarpe/para.rb
@@ -2,17 +2,22 @@ module Scarpe
   class Para
     def initialize(app, text)
       @app = app
-      @text = text
+      @text = Array(text)
       @app.append(render)
     end
 
     def render
-      "<p id=#{object_id}>#{@text}</p>"
+      "<p id=#{object_id}>#{text.join}</p>"
     end
 
-    def replace(text)
-      @text = text
-      @app.window.eval("document.getElementById(#{object_id}).innerText = \"#{text}\"")
+    def replace(new_text)
+      text = new_text
+      app.window.eval("document.getElementById(#{object_id}).innerText = \"#{new_text}\"")
     end
+
+    private
+
+    attr_accessor :text
+    attr_reader :app
   end
 end

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestPara < Minitest::Test
+  def setup
+    @app = Minitest::Mock.new
+    @app.expect :append, nil, [String]
+  end
+
+  def test_renders_paragraph
+    para = Scarpe::Para.new(app, "Hello World")
+    object_id = para.object_id
+
+    assert_equal "<p id=#{object_id}>Hello World</p>", para.render
+  end
+
+  def test_renders_paragraph_with_collection_of_arguments
+    text_collection = [
+      "Testing test test. ",
+      "Breadsticks. ",
+      "Breadsticks. ",
+      "Breadsticks. ",
+      "Very good."
+    ]
+
+    para = Scarpe::Para.new(app, text_collection)
+    object_id = para.object_id
+
+    assert_equal "<p id=#{object_id}>Testing test test. Breadsticks. Breadsticks. Breadsticks. Very good.</p>", para.render
+  end
+
+  private
+
+  attr_reader :app
+end


### PR DESCRIPTION
This is implementation of   

> Support a collection of arguments, joined into one string.
> e.g. para 'this', 'is', 'a', 'string'

from https://github.com/Schwad/scarpe/issues/1


<img width="403" alt="image" src="https://user-images.githubusercontent.com/3978391/217216201-3db1bb0a-50cc-4266-81e1-c3156e74943b.png">
