### PR TITLE
Add tests for HTML module and fix double rendering

### DIFF
--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -1,6 +1,6 @@
 module Scarpe
   class HTML
-    TAGS = %i[div p button]
+    TAGS = %i[div p button ul li]
 
     def self.render(&block)
       new(&block).value
@@ -26,7 +26,8 @@ module Scarpe
     def method_missing(name, *args, &block)
       raise NoMethodError, "no method #{name} for #{self.class.name}" unless TAGS.include?(name)
 
-      @buffer += "<#{name} #{render_attributes(*args)}>"
+      @buffer += "<#{name}#{render_attributes(*args)}>"
+
       if block_given?
         result = block.call(self)
         @buffer += result if result.is_a?(String)
@@ -35,14 +36,19 @@ module Scarpe
       end
 
       @buffer += "</#{name}>"
+
+      nil
     end
 
     private
 
     def render_attributes(attributes = {})
+      return "" if attributes.empty?
+
       attributes[:style] = render_style(attributes[:style]) if attributes[:style]
 
-      attributes.map { |k, v| "#{k}=\"#{v}\"" }.join(" ")
+      result = attributes.map { |k, v| "#{k}=\"#{v}\"" }.join(" ")
+      " #{result}"
     end
 
     def render_style(style)

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestHTML < Minitest::Test
+  def test_works_for_pure_tags
+    subject = ::Scarpe::HTML.render { |h| h.div { "foo" } }
+
+    assert_equal "<div>foo</div>", subject
+  end
+
+  def test_works_for_classes
+    subject = ::Scarpe::HTML.render { |h| h.div(class: "container") { "foo" } }
+
+    assert_equal '<div class="container">foo</div>', subject
+  end
+
+  def test_works_for_style
+    subject = ::Scarpe::HTML.render { |h| h.div(style: { display: "block", width: "100px" }) { "foo" } }
+
+    assert_equal '<div style="display:block;width:100px">foo</div>', subject
+  end
+
+  def test_works_for_string_style
+    subject = ::Scarpe::HTML.render { |h| h.div(style: "display:block;width:100px") { "foo" } }
+
+    assert_equal '<div style="display:block;width:100px">foo</div>', subject
+  end
+
+  def test_works_with_multiple_children
+    subject = ::Scarpe::HTML.render do |h|
+      h.ul do
+        h.li { "one" }
+        h.li { "two" }
+      end
+    end
+
+    assert_equal "<ul><li>one</li><li>two</li></ul>", subject
+  end
+end


### PR DESCRIPTION
Add tests to ensure the HTML module does what it supposed to.

This also fixes a bug that caused 
```ruby
subject = ::Scarpe::HTML.render do |h|
  h.ul do
    h.li { "one" }
    h.li { "two" }
  end
end
```
to render the html twice (the added `nil` return to method missing)