### PR TITLE
edit_line improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 Gemfile.lock
 scarpe_results.txt
+**/.DS_Store

--- a/examples/edit_line.rb
+++ b/examples/edit_line.rb
@@ -1,0 +1,9 @@
+require "scarpe"
+
+Scarpe.app do
+  @name = edit_line("John", width: -100)
+  @greeting = para "Hello #{@name.text}!"
+  @name.change {
+    @greeting.replace("Hello #{@name.text}!")
+  }
+end

--- a/examples/edit_line.rb
+++ b/examples/edit_line.rb
@@ -1,7 +1,8 @@
 require "scarpe"
 
 Scarpe.app do
-  @name = edit_line("John", width: -100)
+  para "Name:"
+  @name = edit_line("John", width: "100%")
   @greeting = para "Hello #{@name.text}!"
   @name.change {
     @greeting.replace("Hello #{@name.text}!")

--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -36,11 +36,11 @@ module Scarpe
     def style
       styles = {}
 
-      styles[:width] = "#{@width}px" if @width
-      styles[:height] = "#{@height}px" if @height
+      styles[:width] = ::Scarpe::Dimensions.length(@width) if @width
+      styles[:height] = ::Scarpe::Dimensions.length(@height) if @height
 
-      styles[:top] = "#{@top}px" if @top
-      styles[:left] = "#{@left}px" if @left
+      styles[:top] = ::Scarpe::Dimensions.length(@top) if @top
+      styles[:left] = ::Scarpe::Dimensions.length(@left) if @left
       styles[:position] = "absolute" if @top || @left
 
       styles

--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -36,11 +36,11 @@ module Scarpe
     def style
       styles = {}
 
-      styles[:width] = ::Scarpe::Dimensions.length(@width) if @width
-      styles[:height] = ::Scarpe::Dimensions.length(@height) if @height
+      styles[:width] = Dimensions.length(@width) if @width
+      styles[:height] = Dimensions.length(@height) if @height
 
-      styles[:top] = ::Scarpe::Dimensions.length(@top) if @top
-      styles[:left] = ::Scarpe::Dimensions.length(@left) if @left
+      styles[:top] = Dimensions.length(@top) if @top
+      styles[:left] = Dimensions.length(@left) if @left
       styles[:position] = "absolute" if @top || @left
 
       styles

--- a/lib/scarpe/edit_line.rb
+++ b/lib/scarpe/edit_line.rb
@@ -47,7 +47,7 @@ module Scarpe
     def style
       styles = {}
 
-      styles[:width] = ::Scarpe::Dimensions.length(@width) if @width
+      styles[:width] = Dimensions.length(@width) if @width
 
       styles
     end

--- a/lib/scarpe/edit_line.rb
+++ b/lib/scarpe/edit_line.rb
@@ -1,9 +1,10 @@
 module Scarpe
   class EditLine
-    def initialize(app, &block)
+    def initialize(app, text = "", width: nil, &block)
       @app = app
       @block = block
-      @text = ""
+      @text = text
+      @width = width
       @app.append(render)
     end
 
@@ -14,7 +15,7 @@ module Scarpe
     def change(&block)
       @block = block
     end
-    
+
     def text
       @text
     end
@@ -33,7 +34,22 @@ module Scarpe
           @block.call(text)
         end
       end
-      "<input id=#{object_id} oninput='scarpeHandler(#{function_name}, this.value)' value='#{@text}'></input>"
+
+      oninput = "scarpeHandler(#{function_name}, this.value)"
+
+      HTML.render do |h|
+        h.input(id: object_id, oninput: oninput, value: @text, style: style)
+      end
+    end
+
+    private
+
+    def style
+      styles = {}
+
+      styles[:width] = ::Scarpe::Dimensions.length(@width) if @width
+
+      styles
     end
   end
 end

--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -32,7 +32,8 @@ module Scarpe
         result = block.call(self)
         @buffer += result if result.is_a?(String)
       else
-        @buffer += args.first
+        result = args.first
+        @buffer += result if result.is_a?(String)
       end
 
       @buffer += "</#{name}>"

--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -1,6 +1,6 @@
 module Scarpe
   class HTML
-    TAGS = %i[div p button ul li]
+    TAGS = %i[div p button ul li input]
 
     def self.render(&block)
       new(&block).value

--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -1,6 +1,8 @@
 module Scarpe
   class HTML
-    TAGS = %i[div p button ul li input]
+    CONTENT_TAGS = %i[div p button ul li].freeze
+    VOID_TAGS = %i[input].freeze
+    TAGS = (CONTENT_TAGS + VOID_TAGS).freeze
 
     def self.render(&block)
       new(&block).value
@@ -26,17 +28,23 @@ module Scarpe
     def method_missing(name, *args, &block)
       raise NoMethodError, "no method #{name} for #{self.class.name}" unless TAGS.include?(name)
 
-      @buffer += "<#{name}#{render_attributes(*args)}>"
 
-      if block_given?
-        result = block.call(self)
-        @buffer += result if result.is_a?(String)
+
+      if VOID_TAGS.include?(name)
+        @buffer += "<#{name}#{render_attributes(*args)} />"
       else
-        result = args.first
-        @buffer += result if result.is_a?(String)
-      end
+        @buffer += "<#{name}#{render_attributes(*args)}>"
 
-      @buffer += "</#{name}>"
+        if block_given?
+          result = block.call(self)
+          @buffer += result if result.is_a?(String)
+        else
+          result = args.first
+          @buffer += result if result.is_a?(String)
+        end
+
+        @buffer += "</#{name}>"
+      end
 
       nil
     end

--- a/lib/scarpe/internal_app.rb
+++ b/lib/scarpe/internal_app.rb
@@ -52,8 +52,8 @@ module Scarpe
     def image(url)
       Scarpe::Image.new(self, url)
     end
-    def edit_line(&block)
-      Scarpe::EditLine.new(self, &block)
+    def edit_line(text = "", width: nil, &block)
+      Scarpe::EditLine.new(self, text, width:, &block)
     end
     def alert(text)
       Scarpe::Alert.new(self, text)

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -42,6 +42,5 @@ class TestHTML < Minitest::Test
     subject = ::Scarpe::HTML.render { |h| h.input(type: "text") }
 
     assert_equal '<input type="text" />', subject
-
   end
 end

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -37,4 +37,11 @@ class TestHTML < Minitest::Test
 
     assert_equal "<ul><li>one</li><li>two</li></ul>", subject
   end
+
+  def test_works_with_void_tag
+    subject = ::Scarpe::HTML.render { |h| h.input(type: "text") }
+
+    assert_equal '<input type="text" />', subject
+
+  end
 end


### PR DESCRIPTION
- Added support for self-closing tags to `Scarpe::HTML` (called `void_tags`)
- Refactored `edit_line` to use `Scarpe::HTML`
- Implemented `Scarpe::Dimensions` in `button` & `edit_line`
- Added width option to `edit_line`
- Added default value option to `edit_line`
- Ignored `.DS_Store` files in repo