### PR TITLE
Use HTML.render for image

### DIFF
--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -1,7 +1,7 @@
 module Scarpe
   class HTML
     CONTENT_TAGS = %i[div p button ul li].freeze
-    VOID_TAGS = %i[input].freeze
+    VOID_TAGS = %i[input img].freeze
     TAGS = (CONTENT_TAGS + VOID_TAGS).freeze
 
     def self.render(&block)

--- a/lib/scarpe/image.rb
+++ b/lib/scarpe/image.rb
@@ -7,8 +7,9 @@ module Scarpe
     end
 
     def render
-      puts "<img id=#{object_id} src=\"#{@url}\">"
-      "<img id=#{object_id} src='#{@url}'>"
+      HTML.render do |h|
+        h.img(id: object_id, src: @url)
+      end
     end
   end
 end


### PR DESCRIPTION
Updates our existing `image.rb` to use our renderer.

Tophat:

Tophatted with running `./exe/scarpe examples/image.rb --dev`

Signed-off-by: Nick Schwaderer <nick.schwaderer@shopify.com>