### PR TITLE
Raise Argument error if void tag given a block

### DIFF
--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -31,6 +31,7 @@ module Scarpe
 
 
       if VOID_TAGS.include?(name)
+        raise ArgumentError, "void tag #{name} cannot have content" if block_given?
         @buffer += "<#{name}#{render_attributes(*args)} />"
       else
         @buffer += "<#{name}#{render_attributes(*args)}>"

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -4,31 +4,31 @@ require "test_helper"
 
 class TestHTML < Minitest::Test
   def test_works_for_pure_tags
-    subject = ::Scarpe::HTML.render { |h| h.div { "foo" } }
+    subject = Scarpe::HTML.render { |h| h.div { "foo" } }
 
     assert_equal "<div>foo</div>", subject
   end
 
   def test_works_for_classes
-    subject = ::Scarpe::HTML.render { |h| h.div(class: "container") { "foo" } }
+    subject = Scarpe::HTML.render { |h| h.div(class: "container") { "foo" } }
 
     assert_equal '<div class="container">foo</div>', subject
   end
 
   def test_works_for_style
-    subject = ::Scarpe::HTML.render { |h| h.div(style: { display: "block", width: "100px" }) { "foo" } }
+    subject = Scarpe::HTML.render { |h| h.div(style: { display: "block", width: "100px" }) { "foo" } }
 
     assert_equal '<div style="display:block;width:100px">foo</div>', subject
   end
 
   def test_works_for_string_style
-    subject = ::Scarpe::HTML.render { |h| h.div(style: "display:block;width:100px") { "foo" } }
+    subject = Scarpe::HTML.render { |h| h.div(style: "display:block;width:100px") { "foo" } }
 
     assert_equal '<div style="display:block;width:100px">foo</div>', subject
   end
 
   def test_works_with_multiple_children
-    subject = ::Scarpe::HTML.render do |h|
+    subject = Scarpe::HTML.render do |h|
       h.ul do
         h.li { "one" }
         h.li { "two" }
@@ -39,8 +39,14 @@ class TestHTML < Minitest::Test
   end
 
   def test_works_with_void_tag
-    subject = ::Scarpe::HTML.render { |h| h.input(type: "text") }
+    subject = Scarpe::HTML.render { |h| h.input(type: "text") }
 
     assert_equal '<input type="text" />', subject
+  end
+
+  def test_raises_with_void_tag_blocks
+    assert_raises(ArgumentError, "void tag input cannot have content") do
+      Scarpe::HTML.render { |h| h.input(type: "text") { "foo" } }
+    end
   end
 end


### PR DESCRIPTION
From pairing session. We don't want blocks in void tags! :) so we tell the user about it

Signed-off-by: Nick Schwaderer <nick.schwaderer@shopify.com>