### PR TITLE
Convert `Scarpe` module to class

### DIFF
--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -4,6 +4,7 @@ require "webview_ruby"
 require "securerandom"
 require "json"
 
+require_relative "scarpe/app"
 require_relative "scarpe/dimensions"
 require_relative "scarpe/html"
 require_relative "scarpe/container"
@@ -18,127 +19,13 @@ require_relative "scarpe/alert"
 require_relative "scarpe/js_eval"
 require_relative "scarpe/internal_app"
 
-module Scarpe
-  # Scarpe::App should only be used from the main thread, due to GTK+ limitations.
-  class App
-    VALID_OPTS = [:debug, :init_code, :result_filename, :periodic_time, :die_after]
-
-    def initialize(opts = {}, &app_code_body)
-      bad_opts = opts.keys - VALID_OPTS
-      raise "Illegal options to Scarpe::App.initialize! #{bad_opts.inspect}" unless bad_opts.empty?
-      @opts = opts
-      @app_code_body = app_code_body
+class Scarpe
+  class << self
+    def app(opts = {}, &blk)
+      app = Scarpe::App.new(opts, &blk)
+      app.init
+      app.run
+      app.destroy
     end
-
-    def init
-      do_debug = @opts[:debug] ? true : false
-
-      puts "INIT APP" if do_debug
-
-      @w = WebviewRuby::Webview.new debug: do_debug
-      @internal_app = Scarpe::InternalApp.new(@w, { debug: do_debug })
-      scarpe_app = self
-
-      @w.bind("scarpeInit") do
-        @internal_app.render(&@app_code_body)
-        monkey_patch_console(@w)
-      end
-
-      @w.bind("scarpeHandler") do |*args|
-        @internal_app.handle_callback(*args)
-      end
-
-      @w.bind("puts") do |*args|
-        puts(*args)
-      end
-
-      # Used to make sure Ruby code can periodically run.
-      @w.bind("scarpePeriodicCallback") do |*args|
-        if @opts[:die_after]
-          if (Time.now - @t_start).to_f > @opts[:die_after]
-            scarpe_app.destroy
-          end
-        end
-      end
-
-      @w.bind("scarpeExit") do
-        scarpe_app.destroy
-      end
-
-      result_file = @opts[:result_filename] || "./scarpe_results.txt"
-      @w.bind("scarpeStatusAndExit") do |*results|
-        puts "Writing results file #{result_file.inspect} to disk!" if @opts[:debug]
-        File.open(result_file, "w") { |f| f.write(JSON.pretty_generate results) }
-        scarpe_app.destroy
-      end
-    end
-
-    def run
-      puts "RUN APP" if @opts[:debug]
-
-      init_code = @opts[:init_code] || ""
-      @t_start = Time.now
-      t_interval = @opts[:periodic_time] || 0.1
-      js_interval = (t_interval.to_f * 1_000.0).to_i
-      @w.init("scarpeInit(); setInterval(scarpePeriodicCallback, #{js_interval}) #{init_code};")
-      @w.set_title("example")
-      @w.set_size(480, 320)
-      @w.navigate("data:text/html, <body id=#{@internal_app.object_id}></body>")
-
-      # This takes control of the main thread and never returns. And it *must* be run from
-      # the main thread. And it stops any Ruby background threads.
-      # That's totally cool and normal, right?
-      @w.run
-    end
-
-    # Uses init() internally, so it won't work once run() is called
-    def js_bind(name, &code)
-      raise "Cannot js_bind on closed or inactive Scarpe::App!" unless @w
-      @w.bind(name, &code)
-    end
-
-    def js_eval(code)
-      raise "Cannot js_eval on closed or inactive Scarpe::App!" unless @w
-      puts "JS EVAL: #{code.inspect}" if @opts[:debug]
-      @w.eval(code)
-    end
-
-    def destroy
-      puts "DESTROY APP" if @opts[:debug]
-      puts "  (but app was already inactive or destroyed)" if @opts[:debug] && @w == nil && @internal_app == nil
-      @internal_app = nil
-      if @w
-        @w.terminate
-        @w.destroy
-        @w = nil
-      end
-    end
-
-    private
-
-    def monkey_patch_console(window)
-      # this forwards all console.log/info/error/warn calls also
-      # to the terminal that is running the scarpe app
-      window.eval <<~JS
-      function patchConsole(fn) {
-        const original = console[fn];
-        console[fn] = function(...args) {
-          original(...args);
-          puts(...args);
-        }
-      };
-      patchConsole('log');
-      patchConsole('info');
-      patchConsole('error');
-      patchConsole('warn');
-      JS
-    end
-  end
-
-  def self.app(opts = {}, &blk)
-    app = Scarpe::App.new(opts, &blk)
-    app.init
-    app.run
-    app.destroy
   end
 end

--- a/lib/scarpe/alert.rb
+++ b/lib/scarpe/alert.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class Alert
     def initialize(app, text)
       @app = app

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+class Scarpe
+  # Scarpe::App should only be used from the main thread, due to GTK+ limitations.
+  class App
+    VALID_OPTS = [:debug, :init_code, :result_filename, :periodic_time, :die_after]
+
+    def initialize(opts = {}, &app_code_body)
+      bad_opts = opts.keys - VALID_OPTS
+      raise "Illegal options to Scarpe::App.initialize! #{bad_opts.inspect}" unless bad_opts.empty?
+      @opts = opts
+      @app_code_body = app_code_body
+    end
+
+    def init
+      do_debug = @opts[:debug] ? true : false
+
+      puts "INIT APP" if do_debug
+
+      @w = WebviewRuby::Webview.new debug: do_debug
+      @internal_app = Scarpe::InternalApp.new(@w, { debug: do_debug })
+      scarpe_app = self
+
+      @w.bind("scarpeInit") do
+        @internal_app.render(&@app_code_body)
+        monkey_patch_console(@w)
+      end
+
+      @w.bind("scarpeHandler") do |*args|
+        @internal_app.handle_callback(*args)
+      end
+
+      @w.bind("puts") do |*args|
+        puts(*args)
+      end
+
+      # Used to make sure Ruby code can periodically run.
+      @w.bind("scarpePeriodicCallback") do |*args|
+        if @opts[:die_after]
+          if (Time.now - @t_start).to_f > @opts[:die_after]
+            scarpe_app.destroy
+          end
+        end
+      end
+
+      @w.bind("scarpeExit") do
+        scarpe_app.destroy
+      end
+
+      result_file = @opts[:result_filename] || "./scarpe_results.txt"
+      @w.bind("scarpeStatusAndExit") do |*results|
+        puts "Writing results file #{result_file.inspect} to disk!" if @opts[:debug]
+        File.open(result_file, "w") { |f| f.write(JSON.pretty_generate results) }
+        scarpe_app.destroy
+      end
+    end
+
+    def run
+      puts "RUN APP" if @opts[:debug]
+
+      init_code = @opts[:init_code] || ""
+      @t_start = Time.now
+      t_interval = @opts[:periodic_time] || 0.1
+      js_interval = (t_interval.to_f * 1_000.0).to_i
+      @w.init("scarpeInit(); setInterval(scarpePeriodicCallback, #{js_interval}) #{init_code};")
+      @w.set_title("example")
+      @w.set_size(480, 320)
+      @w.navigate("data:text/html, <body id=#{@internal_app.object_id}></body>")
+
+      # This takes control of the main thread and never returns. And it *must* be run from
+      # the main thread. And it stops any Ruby background threads.
+      # That's totally cool and normal, right?
+      @w.run
+    end
+
+    # Uses init() internally, so it won't work once run() is called
+    def js_bind(name, &code)
+      raise "Cannot js_bind on closed or inactive Scarpe::App!" unless @w
+      @w.bind(name, &code)
+    end
+
+    def js_eval(code)
+      raise "Cannot js_eval on closed or inactive Scarpe::App!" unless @w
+      puts "JS EVAL: #{code.inspect}" if @opts[:debug]
+      @w.eval(code)
+    end
+
+    def destroy
+      puts "DESTROY APP" if @opts[:debug]
+      puts "  (but app was already inactive or destroyed)" if @opts[:debug] && @w == nil && @internal_app == nil
+      @internal_app = nil
+      if @w
+        @w.terminate
+        @w.destroy
+        @w = nil
+      end
+    end
+
+    private
+
+    def monkey_patch_console(window)
+      # this forwards all console.log/info/error/warn calls also
+      # to the terminal that is running the scarpe app
+      window.eval <<~JS
+      function patchConsole(fn) {
+        const original = console[fn];
+        console[fn] = function(...args) {
+          original(...args);
+          puts(...args);
+        }
+      };
+      patchConsole('log');
+      patchConsole('info');
+      patchConsole('error');
+      patchConsole('warn');
+      JS
+    end
+  end
+end

--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class Button
     def initialize(app, text, width:, height:, top:, left:, &block)
       @app = app

--- a/lib/scarpe/container.rb
+++ b/lib/scarpe/container.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   module Container
     def append(&block)
       prev_id = @app.current_id

--- a/lib/scarpe/dimensions.rb
+++ b/lib/scarpe/dimensions.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class Dimensions
     def self.length(value)
       case value

--- a/lib/scarpe/edit_line.rb
+++ b/lib/scarpe/edit_line.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class EditLine
     def initialize(app, text = "", width: nil, &block)
       @app = app

--- a/lib/scarpe/flow.rb
+++ b/lib/scarpe/flow.rb
@@ -1,14 +1,14 @@
-module Scarpe
+class Scarpe
     class Flow
       include Scarpe::Container
-      
+
       attr_reader :app
       def initialize(app, &block)
         @app = app
         @app.append(render)
         append(&block)
       end
-  
+
       def render
         "<div style='display: flex; flex-direction: row' id=#{object_id}></div>"
       end

--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class HTML
     CONTENT_TAGS = %i[div p button ul li].freeze
     VOID_TAGS = %i[input img].freeze

--- a/lib/scarpe/image.rb
+++ b/lib/scarpe/image.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class Image
     def initialize(app, url)
       @app = app

--- a/lib/scarpe/internal_app.rb
+++ b/lib/scarpe/internal_app.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class InternalApp
     attr_reader :window
     attr_reader :debug

--- a/lib/scarpe/js_eval.rb
+++ b/lib/scarpe/js_eval.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class JSEval
     def initialize(app, js_code)
       @app = app

--- a/lib/scarpe/para.rb
+++ b/lib/scarpe/para.rb
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   class Para
     def initialize(app, text)
       @app = app

--- a/lib/scarpe/stack.rb
+++ b/lib/scarpe/stack.rb
@@ -1,7 +1,7 @@
-module Scarpe
+class Scarpe
   class Stack
     include Scarpe::Container
-    
+
     attr_reader :app
     def initialize(app, width:, margin:, &block)
       @app = app

--- a/lib/scarpe/version.rb
+++ b/lib/scarpe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module Scarpe
+class Scarpe
   VERSION = "0.1.0"
 end

--- a/sig/scarpe.rbs
+++ b/sig/scarpe.rbs
@@ -1,4 +1,4 @@
-module Scarpe
+class Scarpe
   VERSION: String
   # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 end


### PR DESCRIPTION
In order to account for further refactors we plan to do, this PR refactors all occurences of the `Scarpe` module into a class. It also moves `Scarpe::App` from `lib/scarpe.rb` to `lib/scarpe/app.rb`.