### PR TITLE
Add image sizes and positions

### DIFF
--- a/examples/image_with_position_and_size.rb
+++ b/examples/image_with_position_and_size.rb
@@ -1,0 +1,5 @@
+require "scarpe"
+
+Scarpe.app do
+  image "http://shoesrb.com/manual/static/shoes-icon.png", width: 64, height: 256, top: 30, left: 125
+end

--- a/lib/scarpe/image.rb
+++ b/lib/scarpe/image.rb
@@ -1,13 +1,32 @@
 class Scarpe
   class Image < Scarpe::Widget
-    def initialize(url)
+    def initialize(url, width: nil, height: nil, top: nil, left: nil)
       @url = url
+      @width = width
+      @height = height
+      @top = top
+      @left = left
     end
 
     def element
       HTML.render do |h|
-        h.img(id: object_id, src: @url)
+        h.img(id: html_id, src: @url, style: style)
       end
+    end
+
+    private
+
+    def style
+      styles = {}
+
+      styles[:width] = Dimensions.length(@width) if @width
+      styles[:height] = Dimensions.length(@height) if @height
+
+      styles[:top] = Dimensions.length(@top) if @top
+      styles[:left] = Dimensions.length(@left) if @left
+      styles[:position] = "absolute" if @top || @left
+
+      styles
     end
   end
 end

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestImage < Minitest::Test
+  def setup
+    @url = "http://shoesrb.com/manual/static/shoes-icon.png"
+  end
+
+  def test_renders_image
+    img = Scarpe::Image.new(@url)
+
+    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" />", img.to_html
+  end
+
+  def test_renders_image_with_specified_size
+    width = 100
+    height = 50
+    img = Scarpe::Image.new(@url, width: width, height: height)
+
+    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" style=\"width:#{width}px;height:#{height}px\" />", img.to_html
+  end
+
+  def test_renders_image_with_specified_position
+    top = 1
+    left = 5
+    img = Scarpe::Image.new(@url, top: top, left: left)
+
+    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" style=\"top:#{top}px;left:#{left}px;position:absolute\" />", img.to_html
+  end
+
+  def test_renders_image_with_specified_size_and_position
+    width = 100
+    height = 50
+    top = 1
+    left = 5
+    img = Scarpe::Image.new(@url, width: width, height: height, top: top, left: left)
+
+    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" style=\"width:#{width}px;height:#{height}px;top:#{top}px;left:#{left}px;position:absolute\" />", img.to_html
+  end
+
+end


### PR DESCRIPTION
Applies to https://github.com/Schwad/scarpe/issues/5

  - [x] unit testing
  - [x] size
    - [x] `top`
    - [x] `left`
    - [x] `width`
    - [x] `height`
    
  To be done in follow up PR:
  - [ ]  Accepts path to render the image
  - [ ] `image.size`
    - [ ] Returns an array with original size. e.g. `w,h=image.size`
  - [ ] Is clickable `:click` can send to a url

Usage:

```ruby
image "http://shoesrb.com/manual/static/shoes-icon.png", width: 64, height: 256, top: 30, left: 125
```

### Example 
```
bundle exec ruby examples/image_with_position_and_size.rb 
```
<img width="483" alt="Screenshot of running bundle exec ruby examples/image_with_position_and_size.rb " src="https://user-images.githubusercontent.com/1577296/217348789-8bf923f0-5f7e-4e44-9c0f-f5db735c24e3.png">

