### PR TITLE
We shall only support Ruby >=3.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.2
 
 Style/StringLiterals:
   Enabled: true

--- a/scarpe.gemspec
+++ b/scarpe.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Scarpe - shoes but running on webview"
   spec.homepage = "https://github.com/Maaarcocr/scarpe"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 


### PR DESCRIPTION
Pointed out by @DRBragg that we were pointing to older Ruby than we want to. Since this is a new-to-the-world implementation, we're going to bring the best and the brightest Ruby with us.

I don't think there will be backwards compatibility issues with some examples but we can cross that bridge when we get to it. 