### PR TITLE
Introduce html assertion

### DIFF
--- a/test/test_edit_box.rb
+++ b/test/test_edit_box.rb
@@ -13,40 +13,36 @@ class TestEditBox < Minitest::Test
     edit_box = Scarpe::EditBox.new("Hello, World!")
     html_id = edit_box.html_id
 
-    assert_equal(
-      "<textarea id=\"#{html_id}\" oninput=\"scarpeHandler('#{html_id}-change', this.value)\">Hello, World!</textarea>",
-      edit_box.to_html
-    )
+    assert_html edit_box.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{html_id}-change', this.value)" do
+      "Hello, World!"
+    end
   end
 
   def test_renders_textarea_content_block
     edit_box = Scarpe::EditBox.new { "Hello, World!" }
     html_id = edit_box.html_id
 
-    assert_equal(
-      "<textarea id=\"#{html_id}\" oninput=\"scarpeHandler('#{html_id}-change', this.value)\">Hello, World!</textarea>",
-      edit_box.to_html
-    )
+    assert_html edit_box.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{html_id}-change', this.value)" do
+      "Hello, World!"
+    end
   end
 
   def test_textarea_width
     edit_box = Scarpe::EditBox.new("Hello, World!", width: 100)
     html_id = edit_box.html_id
 
-    assert_equal(
-      "<textarea id=\"#{html_id}\" oninput=\"scarpeHandler('#{html_id}-change', this.value)\" style=\"width:100px\">Hello, World!</textarea>",
-      edit_box.to_html
-    )
+    assert_html edit_box.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{html_id}-change', this.value)\" style=\"width:100px" do
+      "Hello, World!"
+    end
   end
 
   def test_textarea_height
     edit_box = Scarpe::EditBox.new("Hello, World!", height: 100)
     html_id = edit_box.html_id
 
-    assert_equal(
-      "<textarea id=\"#{html_id}\" oninput=\"scarpeHandler('#{html_id}-change', this.value)\" style=\"height:100px\">Hello, World!</textarea>",
-      edit_box.to_html
-    )
+    assert_html edit_box.to_html, :textarea, id: html_id, oninput: "scarpeHandler('#{html_id}-change', this.value)\" style=\"height:100px" do
+      "Hello, World!"
+    end
   end
 
   def test_textarea_change_callback

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,3 +50,11 @@ def test_scarpe_app(body_code, opts = {})
     raise
   end
 end
+
+def assert_html(actual_html, expected_tag, **opts, &block)
+  expected_html = Scarpe::HTML.render do |h|
+    h.public_send(expected_tag, opts, &block)
+  end
+
+  assert_equal expected_html, actual_html
+end

--- a/test/test_image.rb
+++ b/test/test_image.rb
@@ -10,7 +10,7 @@ class TestImage < Minitest::Test
   def test_renders_image
     img = Scarpe::Image.new(@url)
 
-    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" />", img.to_html
+    assert_html img.to_html, :img, id: img.html_id, src: @url
   end
 
   def test_renders_image_with_specified_size
@@ -18,7 +18,7 @@ class TestImage < Minitest::Test
     height = 50
     img = Scarpe::Image.new(@url, width: width, height: height)
 
-    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" style=\"width:#{width}px;height:#{height}px\" />", img.to_html
+    assert_html img.to_html, :img, id: img.html_id, src: @url, style: "width:#{width}px;height:#{height}px"
   end
 
   def test_renders_image_with_specified_position
@@ -26,7 +26,7 @@ class TestImage < Minitest::Test
     left = 5
     img = Scarpe::Image.new(@url, top: top, left: left)
 
-    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" style=\"top:#{top}px;left:#{left}px;position:absolute\" />", img.to_html
+    assert_html img.to_html, :img, id: img.html_id, src: @url, style: "top:#{top}px;left:#{left}px;position:absolute"
   end
 
   def test_renders_image_with_specified_size_and_position
@@ -36,7 +36,7 @@ class TestImage < Minitest::Test
     left = 5
     img = Scarpe::Image.new(@url, width: width, height: height, top: top, left: left)
 
-    assert_equal "<img id=\"#{img.html_id}\" src=\"#{@url}\" style=\"width:#{width}px;height:#{height}px;top:#{top}px;left:#{left}px;position:absolute\" />", img.to_html
+    assert_html img.to_html, :img, id: img.html_id, src: @url, style: "width:#{width}px;height:#{height}px;top:#{top}px;left:#{left}px;position:absolute"
   end
 
 end

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -7,7 +7,9 @@ class TestPara < Minitest::Test
     para = Scarpe::Para.new("Hello World")
     html_id = para.html_id
 
-    assert_equal "<p id=\"#{html_id}\" style=\"font-size:12px\">Hello World</p>", para.to_html
+    assert_html para.to_html, :p, id: html_id, style: "font-size:12px" do
+      "Hello World"
+    end
   end
 
   def test_renders_paragraph_with_collection_of_arguments
@@ -20,40 +22,41 @@ class TestPara < Minitest::Test
     ]
 
     para = Scarpe::Para.new(text_collection)
-    html_id = para.html_id
 
-    assert_equal(
-      "<p id=\"#{html_id}\" style=\"font-size:12px\">Testing test test. Breadsticks. Breadsticks. Breadsticks. Very good.</p>",
-      para.to_html
-    )
+    assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
+      "Testing test test. Breadsticks. Breadsticks. Breadsticks. Very good."
+    end
   end
 
   def test_renders_a_magenta_paragraph
     para = Scarpe::Para.new("Hello World", stroke: :magenta)
-    html_id = para.html_id
 
-    assert_equal "<p id=\"#{html_id}\" style=\"color:magenta;font-size:12px\">Hello World</p>", para.to_html
+    assert_html para.to_html, :p, id: para.html_id, style: "color:magenta;font-size:12px" do
+      "Hello World"
+    end
   end
 
   def test_renders_a_blue_paragraph_with_class_attribute
     para = Scarpe::Para.new("Hello World", class: :sea, stroke: :blue)
-    html_id = para.html_id
 
-    assert_equal "<p class=\"sea\" id=\"#{html_id}\" style=\"color:blue;font-size:12px\">Hello World</p>", para.to_html
+    assert_html para.to_html, :p, class: "sea", id: para.html_id, style: "color:blue;font-size:12px" do
+      "Hello World"
+    end
   end
 
   def test_renders_paragraph_with_size_number
     para = Scarpe::Para.new("Oh, to fling and be flung", size: 48)
-    html_id = para.html_id
 
-    assert_equal "<p id=\"#{html_id}\" style=\"font-size:48px\">Oh, to fling and be flung</p>", para.to_html
+    assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
+      "Oh, to fling and be flung"
+    end
   end
 
   def test_renders_paragraph_with_size_symbol
     para = Scarpe::Para.new("Oh, to fling and be flung", size: :banner)
-    html_id = para.html_id
 
-    assert_equal "<p id=\"#{html_id}\" style=\"font-size:48px\">Oh, to fling and be flung</p>", para.to_html
+    assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
+      "Oh, to fling and be flung"
+    end
   end
-
 end


### PR DESCRIPTION
I created an `assert_html` instead of having hand write html in tests. It relies on `Scarpe::HTML` so I didn't use the helper for those tests. For now it only handles tags with only inner text.