### PR TITLE
Widgets can render dom elements

### DIFF
--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -27,7 +27,7 @@ class Scarpe
       @w.bind("scarpeInit") do
         monkey_patch_console(@w)
         @document_root.instance_eval(&@app_code_body)
-        @document_root.append(@document_root.to_html)
+        @document_root.render
         @document_root.end_of_frame
       end
 

--- a/lib/scarpe/button.rb
+++ b/lib/scarpe/button.rb
@@ -11,6 +11,7 @@ class Scarpe
       # Bind to a handler named "click"
       bind("click") do
         @block.call if @block
+        @@document_root.end_of_frame
       end
     end
 

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -2,6 +2,7 @@ class Scarpe
   class DocumentRoot < Scarpe::Widget
     attr_reader :window
     attr_reader :debug
+    attr_reader :children
 
     def initialize(window, opts = {})
       @callbacks = {}
@@ -23,14 +24,6 @@ class Scarpe
 
     def do_js_eval(js)
       @@window.eval(js + ";")
-    end
-
-    def append(el)
-      @@window.eval("document.getElementById(#{html_id}).insertAdjacentHTML('beforeend', \`#{el}\`)")
-    end
-
-    def remove(id)
-      @@window.eval("document.getElementById(#{id}).remove()")
     end
 
     def after_frame(&block)

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -9,9 +9,14 @@ class Scarpe
       @opts = opts
       @debug = opts[:debug] ? true : false
       @after_frame_actions = []
+      @changed = false
 
       Scarpe::Widget.set_window(window)
       Scarpe::Widget.set_document_root(self)
+    end
+
+    def changed!
+      @changed || @changed = true
     end
 
     def bind(name, &block)
@@ -30,8 +35,20 @@ class Scarpe
       @after_frame_actions << block
     end
 
+    def render
+      @@window.eval("document.getElementById(#{html_id}).innerHTML = `#{to_html}`")
+      @changed = false
+    end
+
     def end_of_frame
+      render if should_render?
       @after_frame_actions.each { |block| instance_eval(&block) }
+    end
+
+    private
+
+    def should_render?
+      @changed
     end
   end
 end

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -37,7 +37,7 @@ class Scarpe
         @children ||= []
         @children << widget_instance
 
-        render
+        @@document_root.changed!
 
         widget_instance
       end
@@ -56,10 +56,6 @@ class Scarpe
       else
         child_markup
       end
-    end
-
-    def render
-      @@window.eval("document.getElementById(#{html_id}).innerHTML = `#{to_html}`")
     end
 
     def bind(handler_function_name, &block)

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -36,7 +36,9 @@ class Scarpe
 
         @children ||= []
         @children << widget_instance
-  
+
+        render
+
         widget_instance
       end
       self.send(name, *args, **kwargs, &block)
@@ -56,6 +58,10 @@ class Scarpe
       end
     end
 
+    def render
+      @@window.eval("document.getElementById(#{html_id}).innerHTML = `#{to_html}`")
+    end
+
     def bind(handler_function_name, &block)
       @@document_root.bind(html_id + "-" + handler_function_name, &block)
     end
@@ -69,6 +75,7 @@ class Scarpe
     end
 
     def remove_self
+      @@document_root.children.delete(self)
       @@window.eval("document.getElementById(#{html_id}).remove()")
     end
 


### PR DESCRIPTION
This PR addresses the issue introduced by #53  where a widget could not render a new element. For example:

`link("Click me!") { alert "Access denied!" }`

Should render a new alert. 

`examples/button_alert.rb` demonstrates this functionality.

https://user-images.githubusercontent.com/39735028/217664614-198dccbe-2cd8-4d49-83ff-ae7915bd0f1f.mov

I played around with a lot of ideas for how to do this, just making the solution too complicated. ~So for now I landed on creating a `render` method that replaces _all_ of the elements `innerHTML` instead of using `insertAdjacentHTML`. This way we can just re-render the whole document when a new element is added. Now, I am sure we don't want to re-render everything every time we add a new element to the document, but this seemed like a good start and we can tinker with it and make it smarter.~

After some discussion on discord, I tried a slightly better solution. Now when calling `end_of_frame` on the document root, we check if the root needs to re-render and is so we do it then. Creating new widgets causes the document root to need to re-render. Additionally, clicking a button now calls `end_of_frame`.