### PR TITLE
Readme Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Scarpe
 
 ## _Scarpe Diem: Seize the Shoes_
+![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/Schwad/scarpe/ci.yml?branch=main)
 [![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
+![Discord](https://img.shields.io/discord/1072538177321058377?label=discord)
+
 <img src="https://user-images.githubusercontent.com/7865030/217309905-7f25e3cf-1850-481d-811b-dfddea2df54a.png" width="200" height="200">
 
 "Scarpe" means shoes in Italian. "Scarpe" also means [Shoes](https://github.com/shoes/shoes-deprecated) in modern Ruby and webview!


### PR DESCRIPTION
Add a badge with the build status of main and one with a link to discord to the readme.

In order for the discord one to work correctly, a setting needs to be adjusted in the Discord server.

Link to video with manual:
[![image](https://user-images.githubusercontent.com/6446452/217839686-85f8b1ad-cf58-45a0-ab6e-185e9bf2a514.png)](https://vimeo.com/364220040)
