### PR TITLE
Accept color ranges for border and background

### DIFF
--- a/examples/stack/background.rb
+++ b/examples/stack/background.rb
@@ -3,17 +3,14 @@ require "scarpe"
 Scarpe.app do
   stack width: 0.33 do
     background "purple"
-    border "red", strokewidth: 5, curve: 12
-    button "a button"
-  end
-  stack width: 0.34 do
-    background "purple"
-    border "green", strokewidth: 6
     button "a button"
   end
   stack width: 0.33 do
+    background "red".."green"
+    para "Red to green gradient"
+  end
+  stack width: 0.33 do
     background "purple"
-    border "yellow", strokewidth: 5, curve: 12
     button "a button"
     flow do
       background "purple"

--- a/examples/stack/border.rb
+++ b/examples/stack/border.rb
@@ -1,0 +1,13 @@
+require "scarpe"
+
+Scarpe.app do
+  stack do
+    border "red", strokewidth: 5, curve: 12
+    para "Curved Red"
+  end
+
+  stack do
+    border "#DDD".."#AAA", strokewidth: 10
+    para "Gradient!"
+  end
+end

--- a/examples/stack/gradients.rb
+++ b/examples/stack/gradients.rb
@@ -1,0 +1,8 @@
+require "scarpe"
+
+Scarpe.app do
+  stack height: 200, width: 200 do
+    border "#090979".."#ac033d", strokewidth: 15
+    background "#ac033d".."#090979"
+  end
+end

--- a/examples/stack/stack.rb
+++ b/examples/stack/stack.rb
@@ -2,19 +2,24 @@ Shoes.app do
   stack margin: 50 do
     button "with 50px margin"
   end
+
   stack width: 0.5 do
     button "50% width"
   end
+
   stack width: 80, height: 100 do
     para "This para is in a stack that's 80px wide and 100px high"
   end
+
   stack width: -80 do
     button "100% - 80px width"
   end
+
   flow do
     stack width: 0.33 do
       button "inside flow left 1/3"
     end
+
     stack width: 0.67 do
       button "inside flow right 2/3"
     end

--- a/lib/scarpe/background.rb
+++ b/lib/scarpe/background.rb
@@ -3,14 +3,20 @@
 class Scarpe
   module Background
     def background(color, options = {})
-      @background = color
+      @background_color = color
     end
 
     def style
       styles = (super if defined?(super)) || {}
-      return styles unless @background
+      return styles unless @background_color
 
-      styles.merge({ background: @background })
+      color = if @background_color.is_a?(Range)
+        "linear-gradient(45deg, #{@background_color.first}, #{@background_color.last})"
+      else
+        @background_color
+      end
+
+      styles.merge(background: color)
     end
   end
 end

--- a/lib/scarpe/border.rb
+++ b/lib/scarpe/border.rb
@@ -5,20 +5,25 @@ class Scarpe
     # Considering a signature like this:
     # border "#00D0FF", :strokewidth => 3, :curve => 12
     def border(color, options = {})
-      @border = color
+      @border_color = color
       @options = options
     end
 
     def style
       styles = (super if defined?(super)) || {}
-      return styles unless @border
+      return styles unless @border_color
 
-      styles.merge({
-        "border-color": @border,
+      border_color = if @border_color.is_a?(Range)
+        { "border-image": "linear-gradient(45deg, #{@border_color.first}, #{@border_color.last}) 1" }
+      else
+        { "border-color": @border_color }
+      end
+
+      styles.merge(
         "border-style": "solid",
         "border-width": "#{@options[:strokewidth] || 1}px",
         "border-radius": "#{@options[:curve] || 0}px",
-      })
+      ).merge(border_color)
     end
   end
 end

--- a/test/test_stack.rb
+++ b/test/test_stack.rb
@@ -10,4 +10,32 @@ class TestStack < Minitest::Test
 
     assert(stack.to_html.include?("height:25px"))
   end
+
+  def test_it_can_have_a_background
+    stack = Scarpe::Stack.new do
+      background "red"
+    end
+
+    assert(stack.to_html.include?("background:red"))
+  end
+
+  def test_it_can_have_a_border
+    stack = Scarpe::Stack.new do
+      border "#DDD".."#AAA", strokewidth: 10, curve: 12
+    end
+
+    assert(stack.to_html.include?("border-style:solid;"))
+    assert(stack.to_html.include?("border-width:10px;"))
+    assert(stack.to_html.include?("border-image:linear-gradient(45deg, #DDD, #AAA) 1;"))
+  end
+
+  def test_it_can_have_a_gradient_border_and_background
+    stack = Scarpe::Stack.new do
+      border "#DDD".."#AAA"
+      background "#AAA".."#DDD"
+    end
+
+    assert(stack.to_html.include?("border-image:linear-gradient(45deg, #DDD, #AAA) 1;"))
+    assert(stack.to_html.include?("background:linear-gradient(45deg, #AAA, #DDD);"))
+  end
 end


### PR DESCRIPTION
Make it possible to pass ranges as color parameter:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/3978391/217857210-85dffd39-9bf6-4ea3-a0c9-5c26d9dbbecd.png">

<img width="273" alt="image" src="https://user-images.githubusercontent.com/3978391/217856742-e690e029-f6c2-4471-a4b2-e3ef7e3d65f6.png">
