### PR TITLE
Implement link as widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 "Scarpe" means shoes in Italian. "Scarpe" also means [Shoes](https://github.com/shoes/shoes-deprecated) in modern Ruby and webview!
 
-Scarpe isn't feature complete with any version of Shoes (yet?). We're initially targetting Shoes Classic.
+Scarpe isn't feature complete with any version of Shoes (yet?). We're initially targeting Shoes Classic.
 
 ## Installation
 

--- a/examples/link.rb
+++ b/examples/link.rb
@@ -1,0 +1,5 @@
+require "scarpe"
+
+Scarpe.app do
+  @para = para("Knock knock", "</br>", link("Who's there?") { @para.replace "It's me" })
+end

--- a/examples/link.rb
+++ b/examples/link.rb
@@ -1,5 +1,22 @@
 require "scarpe"
 
 Scarpe.app do
-  @para = para("Knock knock", "</br>", link("Who's there?") { @para.replace "It's me" })
+  def collapsed
+    @para = para(
+      "'Scarpe' means shoes in Italian. 'Scarpe' also means Shoes in...",
+      link("(show more)") { @para.destroy_self; @para = expanded }
+    )
+  end
+
+  def expanded
+    @para = para(
+      "'Scarpe' means shoes in Italian. 'Scarpe' also means Shoes in modern Ruby and webview!</br>",
+      "Scarpe isn't feature complete with any version of Shoes (yet?). We're initially targeting Shoes Classic. ",
+      link("Learn more", click: "http://github.com/schwad/scarpe"),
+      " ",
+      link("(show less)") { @para.destroy_self; @para = collapsed }
+    )
+  end
+
+  @para = collapsed
 end

--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -32,6 +32,7 @@ require_relative "scarpe/em"
 require_relative "scarpe/code"
 
 require_relative "scarpe/document_root"
+require_relative "scarpe/link"
 
 class Scarpe
   class << self

--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -27,12 +27,12 @@ require_relative "scarpe/edit_line"
 require_relative "scarpe/alert"
 
 require_relative "scarpe/text_widget"
+require_relative "scarpe/link"
 require_relative "scarpe/strong"
 require_relative "scarpe/em"
 require_relative "scarpe/code"
 
 require_relative "scarpe/document_root"
-require_relative "scarpe/link"
 
 class Scarpe
   class << self

--- a/lib/scarpe/html.rb
+++ b/lib/scarpe/html.rb
@@ -2,7 +2,7 @@
 
 class Scarpe
   class HTML
-    CONTENT_TAGS = [:div, :p, :button, :ul, :li, :textarea, :a, :strong, :em, :code].freeze
+    CONTENT_TAGS = [:div, :p, :button, :ul, :li, :textarea, :a, :strong, :em, :code, :u].freeze
     VOID_TAGS = [:input, :img].freeze
     TAGS = (CONTENT_TAGS + VOID_TAGS).freeze
 

--- a/lib/scarpe/link.rb
+++ b/lib/scarpe/link.rb
@@ -11,7 +11,13 @@ class Scarpe
 
     def element
       HTML.render do |h|
-        h.u(id: html_id, onclick: handler_js_code("click")) do
+        h.u(
+          id: html_id,
+          style: { color: "blue" },
+          onmouseover: "this.style.color='darkblue'",
+          onmouseout: "this.style.color='blue';",
+          onclick: handler_js_code("click")
+        ) do
           @text
         end
       end

--- a/lib/scarpe/link.rb
+++ b/lib/scarpe/link.rb
@@ -1,7 +1,8 @@
 class Scarpe
   class Link < Scarpe::TextWidget
-    def initialize(text, &block)
+    def initialize(text, click: nil, &block)
       @text = text
+      @click = click
       @block = block
 
       bind("click") do
@@ -10,15 +11,25 @@ class Scarpe
     end
 
     def element
-      HTML.render do |h|
-        h.u(
-          id: html_id,
-          style: { color: "blue" },
-          onmouseover: "this.style.color='darkblue'",
-          onmouseout: "this.style.color='blue';",
-          onclick: handler_js_code("click")
-        ) do
-          @text
+      if @click
+        HTML.render do |h|
+          h.a(
+            href: @click
+          ) do
+            @text
+          end
+        end
+      else
+        HTML.render do |h|
+          h.u(
+            id: html_id,
+            style: { color: "blue" },
+            onmouseover: "this.style.color='darkblue'",
+            onmouseout: "this.style.color='blue';",
+            onclick: handler_js_code("click")
+          ) do
+            @text
+          end
         end
       end
     end

--- a/lib/scarpe/link.rb
+++ b/lib/scarpe/link.rb
@@ -1,0 +1,20 @@
+class Scarpe
+  class Link < Scarpe::TextWidget
+    def initialize(text, &block)
+      @text = text
+      @block = block
+
+      bind("click") do
+        @block.call if @block
+      end
+    end
+
+    def element
+      HTML.render do |h|
+        h.u(id: html_id, onclick: handler_js_code("click")) do
+          @text
+        end
+      end
+    end
+  end
+end

--- a/test/test_link.rb
+++ b/test/test_link.rb
@@ -11,8 +11,23 @@ class TestEditBox < Minitest::Test
 
   def test_link_with_a_block
     link = Scarpe::Link.new("click me") { "thanks" }
+    expected_attributes = {
+      id: link.html_id,
+      style: "color:blue",
+      onmouseover: "this.style.color='darkblue'",
+      onmouseout: "this.style.color='blue';",
+      onclick: link.handler_js_code("click")
+    }
 
-    assert_html link.to_html, :u, id: link.html_id, onclick: link.handler_js_code("click") do
+    assert_html link.to_html, :u, **expected_attributes do
+      "click me"
+    end
+  end
+
+  def test_link_with_a_url
+    link = Scarpe::Link.new("click me", click: "http://github.com/schwad/scarpe")
+
+    assert_html link.to_html, :a, href: "http://github.com/schwad/scarpe" do
       "click me"
     end
   end

--- a/test/test_link.rb
+++ b/test/test_link.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestEditBox < Minitest::Test
+  def setup
+    app = Minitest::Mock.new
+    Scarpe::Widget.set_document_root(app)
+    app.expect :bind, nil, [Object]
+  end
+
+  def test_link_with_a_block
+    link = Scarpe::Link.new("click me") { "thanks" }
+
+    assert_html link.to_html, :u, id: link.html_id, onclick: link.handler_js_code("click") do
+      "click me"
+    end
+  end
+end


### PR DESCRIPTION
Implement link as a text widget. For now link can take either a block, which executes shoes code. Or you can pass an external url to `click:` (internal url will come later with `Shoes.url` I believe). Here is an example of both options in action:


https://user-images.githubusercontent.com/39735028/217861116-c4423521-13ce-4363-8bac-0c480967115d.mov

