### PR TITLE
Replace standardrb with rubocop & ruby-lsp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           bundler-cache: true
       - name: Run linter
-        run: bundle exec standardrb --no-fix
+        run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+inherit_gem:
+  rubocop-shopify: rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 3.2
+  Exclude:
+    - 'bin/**/*'
+    - 'exe/**/*'
+    - 'examples/examples_that_do_not_yet_work/**/*'

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,9 +1,0 @@
-fix: false
-parallel: true
-format: progress
-ruby_version: 3.2.0
-
-ignore:
-  - 'bin/**/*'
-  - 'exe/**/*'
-  - 'examples/examples_that_do_not_yet_work/**/*'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "shopify.ruby-lsp"
+  ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,8 @@ gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"
 
-gem "standard", "~> 1.23", group: [:development, :test]
+gem "rubocop", "~> 1.21"
+
+gem "ruby-lsp", "~> 0.3.8", group: :development
+
+gem "rubocop-shopify", group: :development

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## _Scarpe Diem: Seize the Shoes_
 ![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/Schwad/scarpe/ci.yml?branch=main)
-[![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
+[![Ruby Style Guide](https://img.shields.io/badge/code_style-shopify-brightgreen.svg)](https://github.com/Shopify/ruby-style-guide)
 ![Discord](https://img.shields.io/discord/1072538177321058377?label=discord)
 
 <img src="https://user-images.githubusercontent.com/7865030/217309905-7f25e3cf-1850-481d-811b-dfddea2df54a.png" width="200" height="200">

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rake/testtask"
-require "standard/rake"
+require "rubocop/rake_task"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -10,4 +10,6 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
-task default: [:test, "standard:fix"]
+RuboCop::RakeTask.new
+
+task default: %i[test rubocop]


### PR DESCRIPTION
Turns out standardb and ruby-lsp don't play well together 🤷‍♂️ 

This PR adds rubocop back with the previous config and instead adds ruby-lsp as a language server. It also adds the Ruby-LSP vscode extension as a recommended extension for development.