### PR TITLE
Fix defect in Para#replace setting html in inner text

### DIFF
--- a/examples/button.rb
+++ b/examples/button.rb
@@ -2,6 +2,9 @@ Shoes.app do
   @push = button "Push me"
   @note = para "Nothing pushed so far"
   @push.click {
-    @note.replace "Aha! Click!"
+    @note.replace(
+      "Aha! Click! ",
+      link("Go back") { @note.replace "Nothing pushed so far" }
+    )
   }
 end

--- a/lib/scarpe/para.rb
+++ b/lib/scarpe/para.rb
@@ -39,23 +39,25 @@ class Scarpe
     def to_html
       @children ||= []
 
-      child_markup = @text_children.map do |child|
+      element { child_markup }
+    end
+
+    def replace(*args)
+      @text_children = args || []
+      self.inner_html = child_markup
+    end
+
+    private
+
+    def child_markup
+      @text_children.map do |child|
         if child.respond_to?(:to_html)
           child.to_html
         else
           child
         end
       end.join
-
-      element { child_markup }
     end
-
-    def replace(*args)
-      @text_children = args || []
-      self.inner_text = to_html
-    end
-
-    private
 
     def options
       html_attributes.merge(id: html_id, style: style)

--- a/lib/scarpe/widget.rb
+++ b/lib/scarpe/widget.rb
@@ -102,6 +102,10 @@ class Scarpe
       @@window.eval("document.getElementById(#{html_id}).innerText = \"#{new_text}\"")
     end
 
+    def inner_html=(new_html)
+      @@window.eval("document.getElementById(#{html_id}).innerHTML = `#{new_html}`")
+    end
+
     def value_text=(new_text)
       @@window.eval("document.getElementById(#{html_id}).value = #{new_text}")
     end

--- a/test/test_para.rb
+++ b/test/test_para.rb
@@ -57,4 +57,45 @@ class TestPara < Minitest::Test
       "Oh, to fling and be flung"
     end
   end
+
+  def test_replace_children
+    stub_window
+    para = Scarpe::Para.new("Oh, to fling and be flung", size: :banner)
+
+    para.replace("Oh, to be flung and to fling")
+
+    assert_html para.to_html, :p, id: para.html_id, style: "font-size:48px" do
+      "Oh, to be flung and to fling"
+    end
+  end
+
+  def test_children_can_be_text_widgets
+    strong = Scarpe::Strong.new("I am strong")
+    para = Scarpe::Para.new(strong)
+
+    assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
+      strong.to_html
+    end
+  end
+
+  def test_can_replace_widgets_with_other_widgets
+    stub_window
+    strong = Scarpe::Strong.new("I am strong")
+    em = Scarpe::Strong.new("I am em")
+    para = Scarpe::Para.new(strong)
+
+    para.replace(em)
+
+    assert_html para.to_html, :p, id: para.html_id, style: "font-size:12px" do
+      em.to_html
+    end
+  end
+
+  private
+
+  def stub_window
+    window = Minitest::Mock.new
+    Scarpe::Widget.window = window
+    window.expect :eval, nil, [String]
+  end
 end


### PR DESCRIPTION
@Schwad and I noticed that some of the button examples that relied on `Para#replace` stopped working. The issue seems to be that `replace` does `self.inner_text = to_html`. There were two issues with this. 

One, `to_html` includes the `<p>` itself, so we are actually nesting a new p each time we do this. So, now we just replace the `child_markup` (which I extracted into a method).

Second, since para contains html, I believe we need to set this to `innerHTML` not `innerText`.

Here is a working app with a `para` containing html and not just text.

https://user-images.githubusercontent.com/39735028/217908624-3b0a84a0-6969-45bf-b874-231cac21b3a1.mov

