### PR TITLE
All links are <a> tags

### DIFF
--- a/lib/scarpe/link.rb
+++ b/lib/scarpe/link.rb
@@ -1,37 +1,32 @@
+# frozen_string_literal: true
+
 class Scarpe
   class Link < Scarpe::TextWidget
     def initialize(text, click: nil, &block)
       @text = text
-      @click = click
+      @click = click || "#"
       @block = block
 
       bind("click") do
-        @block.call if @block
+        @block&.call
       end
+      super
     end
 
     def element
-      if @click
-        HTML.render do |h|
-          h.a(
-            href: @click
-          ) do
-            @text
-          end
-        end
-      else
-        HTML.render do |h|
-          h.u(
-            id: html_id,
-            style: { color: "blue" },
-            onmouseover: "this.style.color='darkblue'",
-            onmouseout: "this.style.color='blue';",
-            onclick: handler_js_code("click")
-          ) do
-            @text
-          end
+      HTML.render do |h|
+        h.a(**attributes) do
+          @text
         end
       end
+    end
+
+    def attributes
+      {
+        id: html_id,
+        href: @click,
+        onclick: (handler_js_code("click") if @block),
+      }.compact
     end
   end
 end

--- a/test/test_link.rb
+++ b/test/test_link.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestEditBox < Minitest::Test
+class TestLink < Minitest::Test
   def setup
     app = Minitest::Mock.new
     Scarpe::Widget.document_root = app
@@ -11,15 +11,8 @@ class TestEditBox < Minitest::Test
 
   def test_link_with_a_block
     link = Scarpe::Link.new("click me") { "thanks" }
-    expected_attributes = {
-      id: link.html_id,
-      style: "color:blue",
-      onmouseover: "this.style.color='darkblue'",
-      onmouseout: "this.style.color='blue';",
-      onclick: link.handler_js_code("click")
-    }
 
-    assert_html link.to_html, :u, **expected_attributes do
+    assert_html link.to_html, :a, id: link.html_id, href: "#", onclick: link.handler_js_code("click") do
       "click me"
     end
   end
@@ -27,7 +20,7 @@ class TestEditBox < Minitest::Test
   def test_link_with_a_url
     link = Scarpe::Link.new("click me", click: "http://github.com/schwad/scarpe")
 
-    assert_html link.to_html, :a, href: "http://github.com/schwad/scarpe" do
+    assert_html link.to_html, :a, id: link.html_id, href: "http://github.com/schwad/scarpe" do
       "click me"
     end
   end


### PR DESCRIPTION
Simplify the implementation of `Scapre::Link` by just having everything be an `<a>`. Tbh not sure why I didn't just do this from the start 😅

Also fix the linting violations.