### PR TITLE
Make calculator example work

### DIFF
--- a/examples/examples_that_do_not_yet_work/simple/calc.rb
+++ b/examples/examples_that_do_not_yet_work/simple/calc.rb
@@ -6,9 +6,9 @@ class Calc
   end
 
   def to_s
-    @number.to_s
+    @number&.to_s || @previous.to_s
   end
-  
+
   (0..9).each do |n|
     define_method "press_#{n}" do
       @number = @number.to_i * 10 + n
@@ -17,6 +17,7 @@ class Calc
 
   def press_clear
     @number = 0
+    @previous = 0
   end
 
   {'add' => '+', 'sub' => '-', 'times' => '*', 'div' => '/'}.each do |meth, op|
@@ -59,7 +60,7 @@ Shoes.app :height => 250, :width => 200, :resizable => false do
             when '*'; 'press_times'
             when '/'; 'press_div'
           end
-          
+
           number.send(method)
           number_field.replace strong(number)
         end

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -3,7 +3,9 @@
 class Scarpe
   # Scarpe::App must only be used from the main thread, due to GTK+ limitations.
   class App
-    VALID_OPTS = [:debug, :test_assertions, :init_code, :result_filename, :periodic_time, :die_after]
+    # TODO: Do something with resizable in the future.
+    # For now, we accept it as a valid option so it doesn't crash examples.
+    VALID_OPTS = [:debug, :test_assertions, :init_code, :result_filename, :periodic_time, :die_after, :resizable]
 
     attr_reader :do_debug
 

--- a/lib/scarpe/code.rb
+++ b/lib/scarpe/code.rb
@@ -2,15 +2,6 @@
 
 class Scarpe
   class Code < Scarpe::TextWidget
-    def initialize(text)
-      @text = text
-      super
-    end
-
-    def element
-      HTML.render do |h|
-        h.code { @text }
-      end
-    end
+    default_text_widget_with(:code)
   end
 end

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -2,6 +2,8 @@
 
 class Scarpe
   class DocumentRoot < Scarpe::Widget
+    include Scarpe::Background
+
     attr_reader :debug
     attr_reader :redraw_requested
 
@@ -14,6 +16,12 @@ class Scarpe
 
       Scarpe::Widget.document_root = self
       super
+    end
+
+    def element(&blck)
+      HTML.render do |h|
+        h.div(style:, &blck)
+      end
     end
 
     # Bind a Scarpe callback name; see Scarpe::Widget for how the naming is set up

--- a/lib/scarpe/em.rb
+++ b/lib/scarpe/em.rb
@@ -2,15 +2,6 @@
 
 class Scarpe
   class Em < Scarpe::TextWidget
-    def initialize(text)
-      @text = text
-      super
-    end
-
-    def element
-      HTML.render do |h|
-        h.em { @text }
-      end
-    end
+    default_text_widget_with(:em)
   end
 end

--- a/lib/scarpe/strong.rb
+++ b/lib/scarpe/strong.rb
@@ -2,15 +2,6 @@
 
 class Scarpe
   class Strong < Scarpe::TextWidget
-    def initialize(text)
-      @text = text
-      super
-    end
-
-    def element
-      HTML.render do |h|
-        h.strong { @text }
-      end
-    end
+    default_text_widget_with(:strong)
   end
 end

--- a/lib/scarpe/text_widget.rb
+++ b/lib/scarpe/text_widget.rb
@@ -11,6 +11,19 @@ class Scarpe
         Scarpe::Widget.widget_classes << subclass
       end
       # rubocop:enable Lint/MissingSuper
+
+      def default_text_widget_with(element)
+        define_method(:initialize) do |content|
+          @content = content
+          super(content)
+        end
+
+        define_method(:element) do
+          HTML.render do |h|
+            h.send(element) { @content.to_s }
+          end
+        end
+      end
     end
   end
 end

--- a/lib/scarpe/web_wrangler.rb
+++ b/lib/scarpe/web_wrangler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "webview_ruby"
+require "cgi"
 
 # WebWrangler operates in multiple phases: setup and running.
 
@@ -102,7 +103,29 @@ class Scarpe
     end
 
     def empty
-      "<body id='body-wvroot'><div id='wrapper-wvroot'></div></body>"
+      html = <<~HTML
+        <html>
+          <head id='head-wvroot'>
+            <style id='style-wvroot'>
+              /** Style resets **/
+              body {
+                margin: 0;
+                height: 100%;
+                overflow: hidden;
+              }
+
+              p {
+                margin: 0;
+              }
+            </style>
+          </head>
+          <body id='body-wvroot'>
+            <div id='wrapper-wvroot'></div>
+          </body>
+        </html>
+      HTML
+
+      CGI.escape(html)
     end
 
     public


### PR DESCRIPTION
- Added a `default_text_widget_with(:element)` method to TextWidget
  - Improved that default functionality to call `.to_s` on whatever content is given (the calculator example gives the `strong()` a `Calculator` class instance that implements `.to_s`
  - Made all current "dumb" text widgets call that method (🏜️)
- Accept resizable option to make more examples work (we don't handle it yet though. I've added a comment to point that out)
- Add global style resets in our initial html skeleton (the calculator app now fits in the assigned window width & height!)
- Allow `DocumentRoot` to have a background (& element) by itself
- Add a minor improvement to the calculator example itself (is this ok?)

![image](https://user-images.githubusercontent.com/6446452/218091883-795f77d3-fa46-43cd-891b-1bee12e209bb.png)
