### PR TITLE
Add test control interface

### DIFF
--- a/lib/scarpe.rb
+++ b/lib/scarpe.rb
@@ -5,7 +5,6 @@ require "json"
 
 require_relative "scarpe/version"
 require_relative "scarpe/app"
-require_relative "scarpe/web_wrangler"
 require_relative "scarpe/colors"
 require_relative "scarpe/dimensions"
 require_relative "scarpe/html"

--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -1,17 +1,45 @@
 # frozen_string_literal: true
 
+require_relative "control_interface"
+require_relative "web_wrangler"
+
 class Scarpe
   # Scarpe::App must only be used from the main thread, due to GTK+ limitations.
   class App
     # TODO: Do something with resizable in the future.
     # For now, we accept it as a valid option so it doesn't crash examples.
-    VALID_OPTS = [:debug, :test_assertions, :init_code, :result_filename, :periodic_time, :die_after, :resizable]
+    VALID_OPTS = [
+      :debug,           # print out debug statements
+      :test_assertions, # install additional code used by tests
+      :init_code,       # run the specified JS code at init time
+      :result_filename, # with test assertions, write JSON results to this path
+      :periodic_time,   # for the periodic timeout-check timer, check this often
+      :die_after,       # time out and die after this number of seconds
+      :resizable,       # the app is resizable (currently ignored)
+      :no_control,      # do not run a test-control file, even if one is specified in SCARPE_TEST_CONTROL
+    ]
 
     attr_reader :do_debug
+    attr_reader :control_interface
 
     def initialize(title: "Scarpe!", width: 480, height: 420, **opts, &app_code_body)
       bad_opts = opts.keys - VALID_OPTS
       raise "Illegal options to Scarpe::App.initialize! #{bad_opts.inspect}" unless bad_opts.empty?
+
+      # It's possible to provide a Ruby script by setting
+      # SCARPE_TEST_CONTROL to its file path. This can
+      # allow pre-setting test options or otherwise
+      # performing additional actions not written into
+      # the Shoes app itself.
+      #
+      # The control interface is what lets these files see
+      # events, specify overrides and so on.
+      @control_interface = ControlInterface.new
+      if ENV["SCARPE_TEST_CONTROL"] && !opts[:no_control]
+        @control_interface.instance_eval File.read(ENV["SCARPE_TEST_CONTROL"])
+      end
+
+      opts = @control_interface.app_opts_get_override(opts)
 
       @title = title
       @width = width
@@ -20,6 +48,11 @@ class Scarpe
       @do_debug = opts[:debug] ? true : false
       @view = Scarpe::WebWrangler.new title: title, width: width, height: height, debug: do_debug
       @document_root = Scarpe::DocumentRoot.new(@view, { debug: do_debug })
+
+      # The control interface has to exist to get callbacks like "override Scarpe app opts".
+      # But the Scarpe App needs those options to be created. So we can't pass these to
+      # ControlInterface.new.
+      @control_interface.set_system_components app: self, doc_root: @document_root, wrangler: @view
 
       @opts = opts
       @app_code_body = app_code_body
@@ -76,11 +109,14 @@ class Scarpe
       @view.replace(@document_root.to_html)
       @document_root.clear_needs_update! # We've updated, we don't need to again
       @document_root.end_of_frame
+      @control_interface.dispatch_event(:frame)
     end
 
     def run
       @t_start = Time.now
       @document_root.needs_update!
+
+      @control_interface.dispatch_event(:init)
 
       # This takes control of the main thread and never returns. And it *must* be run from
       # the main thread. And it stops any Ruby background threads.
@@ -102,6 +138,9 @@ class Scarpe
     end
 
     def destroy
+      if @document_root || @view
+        @control_interface.dispatch_event :shutdown
+      end
       @document_root = nil
       if @view
         @view.destroy

--- a/lib/scarpe/control_interface.rb
+++ b/lib/scarpe/control_interface.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# The ControlInterface is used for testing. It's a way to register interest
+# in important events like redraw, init and shutdown, and to override
+# test-relevant values like the options to Shoes.app(). Note that no part
+# of the Scarpe framework should ever *depend* on ControlInterface. It's
+# for testing, not normal operation. If no ControlInterface were ever
+# created or called, Scarpe apps should run fine with no modifications.
+#
+# And if you depend on this from the framework, I'll add a check-mode that
+# doesn't even create one of these. Do NOT test me on this.
+
+class Scarpe
+  class ControlInterface
+    EVENTS = [:init, :shutdown, :frame]
+
+    # The control interface needs to see major system components to hook into their events
+    def initialize
+      @event_handlers = {}
+      EVENTS.each { |e| @event_handlers[e] = [] }
+    end
+
+    # This should get called once, from Scarpe::App
+    def set_system_components(app:, doc_root:, wrangler:)
+      @app = app
+      @doc_root = doc_root
+      @wrangler = wrangler
+    end
+
+    # The control interface has overrides for certain settings. If the override has been specified,
+    # those settings will be overridden.
+
+    # Override the Shoes app opts like "debug:" and "die_after:" with new ones.
+    def override_app_opts(new_opts)
+      @new_app_opts = new_opts
+    end
+
+    # Called by Scarpe::App to get the override options
+    def app_opts_get_override(opts)
+      @new_app_opts || opts
+    end
+
+    # On recognised events, this sets a handler for that event
+    def on_event(event, &block)
+      unless EVENTS.include?(event)
+        raise "Illegal event #{event.inspect}! Valid values are: #{EVENTS.inspect}"
+      end
+
+      @event_handlers[event] << block
+    end
+
+    def js_eval(code)
+      @wrangler.js_eval(code)
+    end
+
+    # Send out the specified event
+    def dispatch_event(event, *args, **keywords)
+      unless EVENTS.include?(event)
+        raise "Illegal event #{event.inspect}! Valid values are: #{EVENTS.inspect}"
+      end
+
+      @event_handlers[event].each do |handler|
+        instance_eval(*args, **keywords, &handler)
+      end
+    end
+  end
+end

--- a/lib/scarpe/document_root.rb
+++ b/lib/scarpe/document_root.rb
@@ -11,7 +11,6 @@ class Scarpe
       @callbacks = {}
       @opts = opts
       @debug = opts[:debug] ? true : false
-      @after_frame_actions = []
       @webview = webview
 
       Scarpe::Widget.document_root = self
@@ -42,26 +41,14 @@ class Scarpe
     def request_redraw!
       return if @redraw_requested
 
-      @webview.eval("setTimeout(scarpeRedrawCallback,0)")
+      @webview.js_eval("setTimeout(scarpeRedrawCallback,0)")
       @redraw_requested = true
-    end
-
-    def after_frame(&block)
-      @after_frame_actions << block
     end
 
     def end_of_frame
       @redraw_requested = false
-      @after_frame_actions.each { |block| instance_eval(&block) }
     end
     alias_method :info, :puts
-
-    # This is a bad thing for the document root to know how to do.
-    # It is only used for after-frame testing callbacks. This method
-    # should be removed when the test infrastructure improves.
-    def do_js_eval(js)
-      @webview.eval(js + ";")
-    end
 
     # The document root manages the connection between widgets and the WebviewWrangler.
     # By centralising this and wrapping in API functions, we can keep from executing

--- a/lib/scarpe/web_wrangler.rb
+++ b/lib/scarpe/web_wrangler.rb
@@ -47,7 +47,7 @@ class Scarpe
 
     # Running callbacks
 
-    def eval(code)
+    def js_eval(code)
       @webview.eval(code)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,54 +10,69 @@ require "minitest/autorun"
 
 # Docs for our Webview lib: https://github.com/Maaarcocr/webview_ruby
 
-SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
+def with_tempfile(prefix, contents)
+  t = Tempfile.new(prefix)
+  t.write(contents)
+  t.flush # Make sure the contents are written out
 
-TEST_OPTS = [:timeout, :allow_fail, :debug]
-def test_scarpe_app(body_code, opts = {})
+  yield(t.path)
+ensure
+  t.close
+  t.unlink
+end
+
+SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
+TEST_OPTS = [:timeout, :allow_fail, :debug, :exit_immediately]
+def test_scarpe_app(body_code, test_code: "", **opts)
   bad_opts = opts.keys - TEST_OPTS
   raise "Bad options passed to test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
 
-  out = Tempfile.new("scarpe_test_results.json")
-  out_path = File.expand_path out.path
-  Tempfile.open("scarpe_test") do |f|
-    do_debug = opts[:debug] ? true : false
-    die_after = opts[:timeout] ? opts[:timeout].to_f : 1.0
-    f.write(
-      "Scarpe.app(test_assertions: true, debug:#{do_debug.inspect}, die_after: #{die_after}, " \
-        "result_filename: #{out_path.inspect}) do\n",
-    )
-    f.write(body_code)
-    f.write("\nend\n")
-    f.flush # Make sure the code is written out
+  do_debug = opts[:debug] ? true : false
+  die_after = opts[:timeout] ? opts[:timeout].to_f : 1.0
+  scarpe_app_code = <<~SCARPE_APP_CODE
+    Scarpe.app do
+      #{body_code}
+    end
+  SCARPE_APP_CODE
 
-    script_location = File.expand_path(f.path)
-    system("ruby #{SCARPE_EXE} --dev #{script_location}")
-    f.unlink
-  end
+  with_tempfile("scarpe_test_results.json", "") do |result_path|
+    scarpe_test_code = <<~SCARPE_TEST_CODE
+      override_app_opts test_assertions: true, debug: #{do_debug}, die_after: #{die_after}, result_filename: #{result_path.inspect}
+    SCARPE_TEST_CODE
+    if opts[:exit_immediately]
+      scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
+        on_event(:frame) {
+          js_eval "scarpeStatusAndExit(true);"
+        }
+      TEST_EXIT_IMMEDIATELY
+    end
+    scarpe_test_code += test_code
 
-  # If failure is okay, don't check for status or assertions
-  return if opts[:allow_fail]
+    with_tempfile("scarpe_test.rb", scarpe_app_code) do |shoes_app_location|
+      with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
+        system("SCARPE_TEST_CONTROL=#{control_file_path} ruby #{SCARPE_EXE} --dev #{shoes_app_location}")
+      end
+    end
 
-  unless File.exist?(out_path)
-    assert(false, "Scarpe app returned no status code!")
-    return
-  end
+    # If failure is okay, don't check for status or assertions
+    return if opts[:allow_fail]
 
-  begin
-    out_data = JSON.parse File.read(out_path)
+    unless File.exist?(result_path)
+      assert(false, "Scarpe app returned no status code!")
+      return
+    end
+
     begin
-      out.unlink
-    rescue
-      nil
-    end # Probably never written
+      out_data = JSON.parse File.read(result_path)
 
-    assert(
-      out_data.respond_to?(:each) && out_data[0],
-      "Scarpe app returned a non-Arrayish or non-truthy status! #{out_data.inspect}",
-    )
-  rescue
-    $stderr.puts "Error parsing JSON data for Scarpe test status!"
-    raise
+      assert(
+        out_data.respond_to?(:each) && out_data[0],
+        "Scarpe app returned a non-Arrayish or non-truthy status! #{out_data.inspect}",
+      )
+    rescue
+      $stderr.puts "Error parsing JSON data for Scarpe test status!"
+      raise
+    end
   end
 end
 

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -8,11 +8,8 @@ class TestScarpe < Minitest::Test
   end
 
   def test_hello_world_app
-    test_scarpe_app <<-'SCARPE_APP'
+    test_scarpe_app(<<-'SCARPE_APP', exit_immediately: true)
       para "Hello World"
-      after_frame {
-        do_js_eval "scarpeStatusAndExit(true);"
-      }
     SCARPE_APP
   end
 
@@ -23,43 +20,30 @@ class TestScarpe < Minitest::Test
   end
 
   def test_button_app
-    test_scarpe_app(<<-'SCARPE_APP', debug: true)
+    test_scarpe_app(<<-'SCARPE_APP', debug: true, exit_immediately: true)
       @push = button "Push me", width: 200, height: 50, top: 109, left: 132
       @note = para "Nothing pushed so far"
       @push.click { @note.replace "Aha! Click!" }
       button_id = @push.object_id
-
-      after_frame {
-        # Problem with do_js_eval - if it fails completely, you get a no-op, not a failure.
-        do_js_eval "val elt = getElementById(#{button_id}); if(elt.style.width != 200) { scarpeStatusAndExit(false, 'Button width is not 200!'); };"
-
-        do_js_eval "scarpeStatusAndExit(true);"
-      }
     SCARPE_APP
   end
 
   def test_button_args_optional
-    test_scarpe_app(<<-'SCARPE_APP')
+    test_scarpe_app(<<-'SCARPE_APP', exit_immediately: true)
       button "Push me"
-      after_frame {
-        do_js_eval "scarpeStatusAndExit(true);"
-      }
     SCARPE_APP
   end
 
   def test_stack_args_optional
-    test_scarpe_app(<<-'SCARPE_APP')
+    test_scarpe_app(<<-'SCARPE_APP', exit_immediately: true)
       stack do
         button "Push me"
       end
-      after_frame {
-        do_js_eval "scarpeStatusAndExit(true);"
-      }
     SCARPE_APP
   end
 
   def test_widgets_exist
-    test_scarpe_app(<<-'SCARPE_APP')
+    test_scarpe_app(<<-'SCARPE_APP', exit_immediately: true)
       stack do
         para "Here I am"
         button "Push me"
@@ -67,9 +51,6 @@ class TestScarpe < Minitest::Test
         edit_line "edit_line here", width: 450
         image "http://shoesrb.com/manual/static/shoes-icon.png"
       end
-      after_frame {
-        do_js_eval "scarpeStatusAndExit(true);"
-      }
     SCARPE_APP
   end
 end


### PR DESCRIPTION
The TestControl interface allows you to modify a Shoes app with a second Ruby file, specified with an environment variable.

For instance, here's what the test_scarpe_app test helper now uses instead of rewriting the opts directly in the code:

~~~
override_app_opts test_assertions: true, debug: true, die_after: 0.1, result_filename: "/long/path/goes/here"
on_event(:frame) {
  js_eval "scarpeStatusAndExit(true);"
}
~~~

We'll be able to do even better soon. The periodic timer and timeout could be done externally like this too, as could returning results and even installing the test assertions.

But this allows calling events on startup, shutdown and per-redraw. It's a good start. It works for our unit tests, and should also work for the "run all the example apps but exit after they load" that people were talking about.