### PR TITLE
Remove app options that are no longer needed with the control interface

### DIFF
--- a/lib/scarpe/control_interface.rb
+++ b/lib/scarpe/control_interface.rb
@@ -14,6 +14,10 @@ class Scarpe
   class ControlInterface
     EVENTS = [:init, :shutdown, :frame]
 
+    attr_reader :app
+    attr_reader :doc_root
+    attr_reader :wrangler
+
     # The control interface needs to see major system components to hook into their events
     def initialize
       @event_handlers = {}

--- a/lib/scarpe/web_wrangler.rb
+++ b/lib/scarpe/web_wrangler.rb
@@ -42,7 +42,8 @@ class Scarpe
 
       @webview.bind(name, &block)
       js_interval = (interval.to_f * 1_000.0).to_i
-      @webview.init("setInterval(scarpePeriodicCallback, #{js_interval});")
+      puts "setInterval(#{name}, #{js_interval});"
+      @webview.init("setInterval(#{name}, #{js_interval});")
     end
 
     # Running callbacks


### PR DESCRIPTION
This isn't working yet - the periodic callback isn't being registered for some reason.

But this will be much improved when it works. This is a *much* more sensible set of app options.