### PR TITLE
Remove app options that are no longer needed with the control interface

### DIFF
--- a/lib/scarpe/app.rb
+++ b/lib/scarpe/app.rb
@@ -10,11 +10,6 @@ class Scarpe
     # For now, we accept it as a valid option so it doesn't crash examples.
     VALID_OPTS = [
       :debug,           # print out debug statements
-      :test_assertions, # install additional code used by tests
-      :init_code,       # run the specified JS code at init time
-      :result_filename, # with test assertions, write JSON results to this path
-      :periodic_time,   # for the periodic timeout-check timer, check this often
-      :die_after,       # time out and die after this number of seconds
       :resizable,       # the app is resizable
       :no_control,      # do not run a test-control file, even if one is specified in SCARPE_TEST_CONTROL
     ]
@@ -74,30 +69,6 @@ class Scarpe
         puts("Redraw!") if do_debug
         redraw_frame if @document_root.redraw_requested
       end
-
-      # We want a timer if timer/timeout options are specified, or if we need to ensure timeouts for tests
-      if @opts[:test_assertions] || @opts[:die_after] || @opts[:periodic_time]
-        # Used to make sure Ruby code can periodically run.
-        @view.periodic_code("scarpePeriodicCallback", @opts[:periodic_time] || 0.1) do |*_args|
-          # @t_start is set on run()
-          if @opts[:die_after] && ((Time.now - @t_start).to_f > @opts[:die_after])
-            scarpe_app.destroy
-          end
-        end
-      end
-
-      if @opts[:test_assertions]
-        result_file = @opts[:result_filename] || "./scarpe_results.txt"
-        @view.bind("scarpeStatusAndExit") do |*results|
-          puts "Writing results file #{result_file.inspect} to disk!" if @opts[:debug]
-          File.open(result_file, "w") { |f| f.write(JSON.pretty_generate(results)) }
-          scarpe_app.destroy
-        end
-      end
-
-      if @opts[:init_code]
-        @view.init_code("scarpeUserInitCode", @opts[:init_code] + ";")
-      end
     end
 
     # Draw a frame, call the per-frame callback(s)
@@ -109,7 +80,6 @@ class Scarpe
     end
 
     def run
-      @t_start = Time.now
       @document_root.needs_update!
 
       @control_interface.dispatch_event(:init)

--- a/lib/scarpe/control_interface.rb
+++ b/lib/scarpe/control_interface.rb
@@ -14,6 +14,10 @@ class Scarpe
   class ControlInterface
     EVENTS = [:init, :shutdown, :frame]
 
+    attr_reader :app
+    attr_reader :doc_root
+    attr_reader :wrangler
+
     # The control interface needs to see major system components to hook into their events
     def initialize
       @event_handlers = {}

--- a/lib/scarpe/web_wrangler.rb
+++ b/lib/scarpe/web_wrangler.rb
@@ -21,6 +21,10 @@ class Scarpe
       @debug = debug
 
       puts "Creating WebWrangler..." if debug
+
+      @webview.bind("puts") do |*args|
+        puts(*args)
+      end
     end
 
     ### Setup-mode Callbacks
@@ -43,7 +47,7 @@ class Scarpe
 
       @webview.bind(name, &block)
       js_interval = (interval.to_f * 1_000.0).to_i
-      @webview.init("setInterval(scarpePeriodicCallback, #{js_interval});")
+      @webview.init("setInterval(#{name}, #{js_interval});")
     end
 
     # Running callbacks
@@ -57,9 +61,6 @@ class Scarpe
 
     def run
       puts "Run..." if @debug
-      @webview.bind("puts") do |*args|
-        puts(*args)
-      end
 
       # From webview:
       # 0 - Width and height are default size

--- a/test/test_examples.rb
+++ b/test/test_examples.rb
@@ -11,7 +11,6 @@ class TestScarpe < Minitest::Test
     puts "Testing #{examples_to_test.count} examples"
 
     examples_to_test.each do |example|
-      puts "Testing #{example}"
       test_scarpe_app(example, exit_immediately: true)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,21 +39,39 @@ def test_scarpe_app(test_app_location, test_code: "", **opts)
 
   with_tempfile("scarpe_test_results.json", "") do |result_path|
     do_debug = opts[:debug] ? true : false
-    die_after = opts[:timeout] ? opts[:timeout].to_f : 1.0
-
+    die_after = opts[:timeout] ? opts[:timeout].to_f : 0.1
     scarpe_test_code = <<~SCARPE_TEST_CODE
-      override_app_opts test_assertions: true, debug: #{do_debug}, die_after: #{die_after}, result_filename: #{result_path.inspect}
+      override_app_opts debug: #{do_debug}
+
+      on_event(:init) do
+        t_start = Time.now
+        wrangler.periodic_code("scarpePeriodicCallback", 0.1) do |*_args|
+          if ((Time.now - t_start).to_f > #{die_after})
+            app.destroy
+          end
+        end
+
+        result_file = #{result_path.inspect}
+        wrangler.bind("scarpeStatusAndExit") do |*results|
+          puts "Writing results file \#{result_file.inspect} to disk!" if #{do_debug}
+          File.open(result_file, "w") { |f| f.write(JSON.pretty_generate(results)) }
+          app.destroy
+        end
+      end
     SCARPE_TEST_CODE
 
     if opts[:exit_immediately]
       scarpe_test_code += <<~TEST_EXIT_IMMEDIATELY
-        on_event(:frame) {
+        on_event(:frame) do
           js_eval "scarpeStatusAndExit(true);"
-        }
+        end
       TEST_EXIT_IMMEDIATELY
     end
 
     scarpe_test_code += test_code
+
+    # No results until we write them
+    File.unlink(result_path)
 
     with_tempfile("scarpe_control.rb", scarpe_test_code) do |control_file_path|
       system("SCARPE_TEST_CONTROL=#{control_file_path} ruby #{SCARPE_EXE} --dev #{test_app_location}")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,17 +24,11 @@ end
 SCARPE_EXE = File.expand_path("../exe/scarpe", __dir__)
 TEST_OPTS = [:timeout, :allow_fail, :debug, :exit_immediately]
 
-def test_scarpe_code(body_code, test_code: "", **opts)
+def test_scarpe_code(scarpe_app_code, test_code: "", **opts)
   bad_opts = opts.keys - TEST_OPTS
-  raise "Bad options passed to test_scarpe_app: #{bad_opts.inspect}!" unless bad_opts.empty?
+  raise "Bad options passed to test_scarpe_code: #{bad_opts.inspect}!" unless bad_opts.empty?
 
-  scarpe_app_code = <<~SCARPE_APP_CODE
-    Scarpe.app do
-      #{body_code}
-    end
-  SCARPE_APP_CODE
-
-  with_tempfile("test_app.rb", scarpe_app_code) do |test_app_location|
+  with_tempfile("scarpe_test_app.rb", scarpe_app_code) do |test_app_location|
     test_scarpe_app(test_app_location, test_code: test_code, **opts)
   end
 end

--- a/test/test_scarpe.rb
+++ b/test/test_scarpe.rb
@@ -9,47 +9,59 @@ class TestScarpe < Minitest::Test
 
   def test_hello_world_app
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      para "Hello World"
+      Scarpe.app do
+        para "Hello World"
+      end
     SCARPE_APP
   end
 
   def test_app_timeout
     test_scarpe_code(<<-'SCARPE_APP', timeout: 0.1, allow_fail: true)
-      para "Just waiting for this to time out"
+      Scarpe.app do
+        para "Just waiting for this to time out"
+      end
     SCARPE_APP
   end
 
   def test_button_app
     test_scarpe_code(<<-'SCARPE_APP', debug: true, exit_immediately: true)
-      @push = button "Push me", width: 200, height: 50, top: 109, left: 132
-      @note = para "Nothing pushed so far"
-      @push.click { @note.replace "Aha! Click!" }
-      button_id = @push.object_id
+      Scarpe.app do
+        @push = button "Push me", width: 200, height: 50, top: 109, left: 132
+        @note = para "Nothing pushed so far"
+        @push.click { @note.replace "Aha! Click!" }
+        button_id = @push.object_id
+      end
     SCARPE_APP
   end
 
   def test_button_args_optional
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      button "Push me"
+      Scarpe.app do
+        button "Push me"
+      end
     SCARPE_APP
   end
 
   def test_stack_args_optional
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      stack do
-        button "Push me"
+      Scarpe.app do
+        stack do
+          button "Push me"
+        end
       end
     SCARPE_APP
   end
 
   def test_widgets_exist
     test_scarpe_code(<<-'SCARPE_APP', exit_immediately: true)
-      stack do
-        para "Here I am"
-        button "Push me"
-        alert "I am an alert!"
-        edit_line "edit_line here", width: 450
-        image "http://shoesrb.com/manual/static/shoes-icon.png"
+      Scarpe.app do
+        stack do
+          para "Here I am"
+          button "Push me"
+          alert "I am an alert!"
+          edit_line "edit_line here", width: 450
+          image "http://shoesrb.com/manual/static/shoes-icon.png"
+        end
       end
     SCARPE_APP
   end


### PR DESCRIPTION
We had a bunch of app options that were basically unit test helpers -- die_after, periodic_time, result_filename, test_assertions. Init_code was never used, but was needed when we had no way to add Ruby hooks for that.

ControlInterface changes all that, so we can do init_code using it if we ever need it, and all the others can be inserted via test_helper. None of them need to be core parts of WebWrangler.

Nick, this also permits your idea of a runtime Shoes debug override/mode that can be added to an existing Shoes app. You'd just make a file that tells it to use debug mode.